### PR TITLE
Adjust PcapPlusPlus to support building against DPDK from Ubuntu 18.04 repository

### DIFF
--- a/Pcap++/Makefile
+++ b/Pcap++/Makefile
@@ -55,7 +55,7 @@ ifdef PF_RING_HOME
 INCLUDES += -I$(PF_RING_HOME)/userland/lib -I$(PF_RING_HOME)/kernel
 endif
 ifdef USE_DPDK
-INCLUDES += -I"$(RTE_SDK)/build/include"
+INCLUDES += -I"/usr/include/dpdk"
 endif
 ifdef LIBPCAP_INLCUDE_DIR
 INCLUDES += -I"$(LIBPCAP_INLCUDE_DIR)"

--- a/configure-linux.sh
+++ b/configure-linux.sh
@@ -263,7 +263,7 @@ fi
 # function to extract DPDK major + minor version from <DPDK_HOM>/pkg/dpdk.spec file
 # return: DPDK version (major + minor only)
 function get_dpdk_version() {
-   echo $(grep "Version" $DPDK_HOME/pkg/dpdk.spec | cut -d' ' -f2 | cut -d'.' -f 1,2)
+   echo "17.11.3" 
 }
 
 # function to compare between 2 versions (each constructed of major + minor)

--- a/mk/PcapPlusPlus.mk.dpdk
+++ b/mk/PcapPlusPlus.mk.dpdk
@@ -1,10 +1,10 @@
 ### DPDK ###
 
 # includes
-PCAPPP_INCLUDES += -I$(RTE_SDK)/build/include
+PCAPPP_INCLUDES += -I/usr/include/dpdk
 
 # libs dir
-PCAPPP_LIBS_DIR += -L$(RTE_SDK)/build/lib -L/lib64
+PCAPPP_LIBS_DIR += -L/lib64
 
 #flags
 PCAPPP_BUILD_FLAGS += -msse -msse2 -msse3 -Wall


### PR DESCRIPTION
Adjust PcapPlusPlus to support building against DPDK from Ubuntu 18.04 repository